### PR TITLE
add global envvars

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -13,10 +13,11 @@ import (
 
 // EstafetteManifest is the object that the .estafette.yaml deserializes to
 type EstafetteManifest struct {
-	Builder   EstafetteBuilder     `yaml:"builder,omitempty"`
-	Version   EstafetteVersion     `yaml:"version,omitempty"`
-	Labels    map[string]string    `yaml:"labels,omitempty"`
-	Pipelines []*EstafettePipeline `yaml:"dummy,omitempty"`
+	Builder       EstafetteBuilder     `yaml:"builder,omitempty"`
+	Version       EstafetteVersion     `yaml:"version,omitempty"`
+	Labels        map[string]string    `yaml:"labels,omitempty"`
+	GlobalEnvVars map[string]string    `yaml:"env,omitempty"`
+	Pipelines     []*EstafettePipeline `yaml:"dummy,omitempty"`
 }
 
 // unmarshalYAML parses the .estafette.yaml file into an EstafetteManifest object

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -171,6 +171,16 @@ func TestReadManifestFromFile(t *testing.T) {
 		assert.Equal(t, "{{branch}}", manifest.Version.SemVer.LabelTemplate)
 		assert.Equal(t, "master", manifest.Version.SemVer.ReleaseBranch)
 	})
+
+	t.Run("ReturnsManifestWithGlobalEnvVars", func(t *testing.T) {
+
+		// act
+		manifest, err := ReadManifestFromFile("test-manifest.yaml")
+
+		assert.Nil(t, err)
+		assert.Equal(t, "Greetings", manifest.GlobalEnvVars["VAR_A"])
+		assert.Equal(t, "World", manifest.GlobalEnvVars["VAR_B"])
+	})
 }
 
 func TestVersion(t *testing.T) {

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -14,6 +14,10 @@ version:
     labelTemplate: '{{branch}}'
     releaseBranch: master
 
+env:
+  VAR_A: Greetings
+  VAR_B: World
+
 pipelines:
   build:
     image: golang:1.8.0-alpine


### PR DESCRIPTION
First step for https://github.com/estafette/estafette-ci-builder/issues/9 is to add it to the manifest. 

Next to update the vendored package in https://github.com/estafette/estafette-ci-api and https://github.com/estafette/estafette-ci-builder. In the builder some logic needs to be added to automatically inject global envvars in the pipelines and to override them if a step redefines the same envvar name.