### PR TITLE
See what triggers could look like in the yaml format

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -15,6 +15,7 @@ type EstafetteManifest struct {
 	Labels        map[string]string   `yaml:"labels,omitempty"`
 	Version       EstafetteVersion    `yaml:"version,omitempty"`
 	GlobalEnvVars map[string]string   `yaml:"env,omitempty"`
+	Triggers      []*EstafetteTrigger `yaml:"triggers,omitempty"`
 	Stages        []*EstafetteStage   `yaml:"-" json:"Pipelines,omitempty"`
 	Releases      []*EstafetteRelease `yaml:"-"`
 }
@@ -23,13 +24,14 @@ type EstafetteManifest struct {
 func (c *EstafetteManifest) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
 
 	var aux struct {
-		Builder             EstafetteBuilder  `yaml:"builder"`
-		Labels              map[string]string `yaml:"labels"`
-		Version             EstafetteVersion  `yaml:"version"`
-		GlobalEnvVars       map[string]string `yaml:"env"`
-		DeprecatedPipelines yaml.MapSlice     `yaml:"pipelines"`
-		Stages              yaml.MapSlice     `yaml:"stages"`
-		Releases            yaml.MapSlice     `yaml:"releases"`
+		Builder             EstafetteBuilder    `yaml:"builder"`
+		Labels              map[string]string   `yaml:"labels"`
+		Version             EstafetteVersion    `yaml:"version"`
+		GlobalEnvVars       map[string]string   `yaml:"env"`
+		Triggers            []*EstafetteTrigger `yaml:"triggers,omitempty"`
+		DeprecatedPipelines yaml.MapSlice       `yaml:"pipelines"`
+		Stages              yaml.MapSlice       `yaml:"stages"`
+		Releases            yaml.MapSlice       `yaml:"releases"`
 	}
 
 	// unmarshal to auxiliary type
@@ -42,6 +44,7 @@ func (c *EstafetteManifest) UnmarshalYAML(unmarshal func(interface{}) error) (er
 	c.Version = aux.Version
 	c.Labels = aux.Labels
 	c.GlobalEnvVars = aux.GlobalEnvVars
+	c.Triggers = aux.Triggers
 
 	// provide backwards compatibility for the deprecated pipelines section now renamed to stages
 	if len(aux.Stages) == 0 && len(aux.DeprecatedPipelines) > 0 {
@@ -96,18 +99,20 @@ func (c *EstafetteManifest) UnmarshalYAML(unmarshal func(interface{}) error) (er
 // MarshalYAML customizes marshalling an EstafetteManifest
 func (c EstafetteManifest) MarshalYAML() (out interface{}, err error) {
 	var aux struct {
-		Builder       EstafetteBuilder  `yaml:"builder,omitempty"`
-		Labels        map[string]string `yaml:"labels,omitempty"`
-		Version       EstafetteVersion  `yaml:"version,omitempty"`
-		GlobalEnvVars map[string]string `yaml:"env,omitempty"`
-		Stages        yaml.MapSlice     `yaml:"stages,omitempty"`
-		Releases      yaml.MapSlice     `yaml:"releases,omitempty"`
+		Builder       EstafetteBuilder    `yaml:"builder,omitempty"`
+		Labels        map[string]string   `yaml:"labels,omitempty"`
+		Version       EstafetteVersion    `yaml:"version,omitempty"`
+		GlobalEnvVars map[string]string   `yaml:"env,omitempty"`
+		Triggers      []*EstafetteTrigger `yaml:"triggers,omitempty"`
+		Stages        yaml.MapSlice       `yaml:"stages,omitempty"`
+		Releases      yaml.MapSlice       `yaml:"releases,omitempty"`
 	}
 
 	aux.Builder = c.Builder
 	aux.Labels = c.Labels
 	aux.Version = c.Version
 	aux.GlobalEnvVars = c.GlobalEnvVars
+	aux.Triggers = c.Triggers
 
 	for _, stage := range c.Stages {
 		aux.Stages = append(aux.Stages, yaml.MapItem{

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -264,17 +264,17 @@ func TestReadManifestFromFile(t *testing.T) {
 		assert.Equal(t, "pipeline-build-finished", manifest.Triggers[0].Event)
 		assert.Equal(t, "github.com/estafette/estafette-ci-manifest", manifest.Triggers[0].Filter.Pipeline)
 		assert.Equal(t, "master|release", manifest.Triggers[0].Filter.Branch)
-		assert.Equal(t, "master", manifest.Triggers[0].Then.Branch)
+		assert.Equal(t, "master", manifest.Triggers[0].Run.Branch)
 
 		assert.Equal(t, "pipeline-build-started", manifest.Triggers[1].Event)
 		assert.Equal(t, "github.com/estafette/estafette-ci-contracts", manifest.Triggers[1].Filter.Pipeline)
 		assert.Equal(t, "master|release", manifest.Triggers[1].Filter.Branch)
-		assert.Equal(t, "master", manifest.Triggers[1].Then.Branch)
+		assert.Equal(t, "master", manifest.Triggers[1].Run.Branch)
 
 		assert.Equal(t, "docker-image-pushed", manifest.Triggers[2].Event)
 		assert.Equal(t, "golang", manifest.Triggers[2].Filter.Image)
 		assert.Equal(t, "1\\.8\\..+", manifest.Triggers[2].Filter.Tag)
-		assert.Equal(t, "master", manifest.Triggers[2].Then.Branch)
+		assert.Equal(t, "master", manifest.Triggers[2].Run.Branch)
 	})
 
 	t.Run("ReturnsReleaseTargetWithTriggers", func(t *testing.T) {
@@ -292,10 +292,10 @@ func TestReadManifestFromFile(t *testing.T) {
 			assert.Equal(t, "pipeline-build-finished", developmentRelease.Triggers[0].Event)
 			assert.Equal(t, "", developmentRelease.Triggers[0].Filter.Pipeline)
 			assert.Equal(t, ".+", developmentRelease.Triggers[0].Filter.Branch)
-			assert.Equal(t, ".+", developmentRelease.Triggers[0].Then.Branch)
+			assert.Equal(t, ".+", developmentRelease.Triggers[0].Run.Branch)
 			assert.Equal(t, "cron", developmentRelease.Triggers[1].Event)
 			assert.Equal(t, "*/5 * * * *", developmentRelease.Triggers[1].Filter.Cron)
-			assert.Equal(t, "master", developmentRelease.Triggers[1].Then.Branch)
+			assert.Equal(t, "master", developmentRelease.Triggers[1].Run.Branch)
 
 			stagingRelease := manifest.Releases[3]
 			assert.Equal(t, "staging", stagingRelease.Name)
@@ -303,7 +303,7 @@ func TestReadManifestFromFile(t *testing.T) {
 			assert.Equal(t, "pipeline-release-finished", stagingRelease.Triggers[0].Event)
 			assert.Equal(t, "this", stagingRelease.Triggers[0].Filter.Pipeline)
 			assert.Equal(t, "development", stagingRelease.Triggers[0].Filter.Target)
-			assert.Equal(t, "master", stagingRelease.Triggers[0].Then.Branch)
+			assert.Equal(t, "master", stagingRelease.Triggers[0].Run.Branch)
 
 			productionRelease := manifest.Releases[4]
 			assert.Equal(t, "production", productionRelease.Name)
@@ -313,8 +313,8 @@ func TestReadManifestFromFile(t *testing.T) {
 			assert.Equal(t, "staging", productionRelease.Triggers[0].Filter.Target)
 			assert.Equal(t, "succeeded", productionRelease.Triggers[0].Filter.Status)
 			assert.Equal(t, "master", productionRelease.Triggers[0].Filter.Branch)
-			assert.Equal(t, "master", productionRelease.Triggers[0].Then.Branch)
-			assert.Equal(t, "deploy-canary", productionRelease.Triggers[0].Then.Action)
+			assert.Equal(t, "master", productionRelease.Triggers[0].Run.Branch)
+			assert.Equal(t, "deploy-canary", productionRelease.Triggers[0].Run.Action)
 		}
 	})
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -301,7 +301,7 @@ func TestReadManifestFromFile(t *testing.T) {
 			assert.Equal(t, "staging", stagingRelease.Name)
 			assert.Equal(t, 1, len(stagingRelease.Triggers))
 			assert.Equal(t, "pipeline-release-finished", stagingRelease.Triggers[0].Event)
-			assert.Equal(t, "", stagingRelease.Triggers[0].Filter.Pipeline)
+			assert.Equal(t, "this", stagingRelease.Triggers[0].Filter.Pipeline)
 			assert.Equal(t, "development", stagingRelease.Triggers[0].Filter.Target)
 			assert.Equal(t, "master", stagingRelease.Triggers[0].Then.Branch)
 
@@ -309,7 +309,7 @@ func TestReadManifestFromFile(t *testing.T) {
 			assert.Equal(t, "production", productionRelease.Name)
 			assert.Equal(t, 1, len(productionRelease.Triggers))
 			assert.Equal(t, "pipeline-release-finished", productionRelease.Triggers[0].Event)
-			assert.Equal(t, "", productionRelease.Triggers[0].Filter.Pipeline)
+			assert.Equal(t, "this", productionRelease.Triggers[0].Filter.Pipeline)
 			assert.Equal(t, "staging", productionRelease.Triggers[0].Filter.Target)
 			assert.Equal(t, "succeeded", productionRelease.Triggers[0].Filter.Status)
 			assert.Equal(t, "master", productionRelease.Triggers[0].Filter.Branch)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -260,14 +260,18 @@ func TestReadManifestFromFile(t *testing.T) {
 
 		assert.Nil(t, err)
 
-		assert.Equal(t, 2, len(manifest.Triggers))
+		assert.Equal(t, 3, len(manifest.Triggers))
 		assert.Equal(t, "pipeline", manifest.Triggers[0].Type)
 		assert.Equal(t, "github.com/estafette/estafette-ci-manifest/build", manifest.Triggers[0].Reference)
-		assert.Equal(t, "release", manifest.Triggers[0].Branch)
+		assert.Equal(t, "release", manifest.Triggers[0].Filter)
 
 		assert.Equal(t, "pipeline", manifest.Triggers[1].Type)
 		assert.Equal(t, "github.com/estafette/estafette-ci-contracts/build", manifest.Triggers[1].Reference)
-		assert.Equal(t, "release", manifest.Triggers[1].Branch)
+		assert.Equal(t, "release", manifest.Triggers[1].Filter)
+
+		assert.Equal(t, "docker", manifest.Triggers[2].Type)
+		assert.Equal(t, "golang", manifest.Triggers[2].Reference)
+		assert.Equal(t, "1.8.0-alpine", manifest.Triggers[2].Filter)
 	})
 
 	t.Run("ReturnsReleaseTargetWithTriggers", func(t *testing.T) {
@@ -280,16 +284,18 @@ func TestReadManifestFromFile(t *testing.T) {
 		if assert.Equal(t, 6, len(manifest.Releases)) {
 
 			assert.Equal(t, "development", manifest.Releases[2].Name)
-			assert.Equal(t, 1, len(manifest.Releases[2].Triggers))
+			assert.Equal(t, 2, len(manifest.Releases[2].Triggers))
 			assert.Equal(t, "pipeline", manifest.Releases[2].Triggers[0].Type)
 			assert.Equal(t, "this/build", manifest.Releases[2].Triggers[0].Reference)
-			assert.Equal(t, "any", manifest.Releases[2].Triggers[0].Branch)
+			assert.Equal(t, "branch:release", manifest.Releases[2].Triggers[0].Filter)
+			assert.Equal(t, "cron", manifest.Releases[2].Triggers[1].Type)
+			assert.Equal(t, "*/5 * * * *", manifest.Releases[2].Triggers[1].Reference)
 
 			assert.Equal(t, "staging", manifest.Releases[3].Name)
 			assert.Equal(t, 1, len(manifest.Releases[3].Triggers))
 			assert.Equal(t, "pipeline", manifest.Releases[3].Triggers[0].Type)
 			assert.Equal(t, "this/releases/development", manifest.Releases[3].Triggers[0].Reference)
-			assert.Equal(t, "release", manifest.Releases[3].Triggers[0].Branch)
+			assert.Equal(t, "", manifest.Releases[3].Triggers[0].Filter)
 		}
 	})
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -253,6 +253,29 @@ func TestReadManifestFromFile(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsReleaseTargetWithTriggers", func(t *testing.T) {
+
+		// act
+		manifest, err := ReadManifestFromFile("test-manifest.yaml")
+
+		assert.Nil(t, err)
+
+		if assert.Equal(t, 6, len(manifest.Releases)) {
+
+			assert.Equal(t, "development", manifest.Releases[2].Name)
+			assert.Equal(t, 1, len(manifest.Releases[2].Triggers))
+			assert.Equal(t, "pipeline", manifest.Releases[2].Triggers[0].Type)
+			assert.Equal(t, "this/build", manifest.Releases[2].Triggers[0].Reference)
+			assert.Equal(t, "any", manifest.Releases[2].Triggers[0].Branch)
+
+			assert.Equal(t, "staging", manifest.Releases[3].Name)
+			assert.Equal(t, 1, len(manifest.Releases[3].Triggers))
+			assert.Equal(t, "pipeline", manifest.Releases[3].Triggers[0].Type)
+			assert.Equal(t, "this/releases/development", manifest.Releases[3].Triggers[0].Reference)
+			assert.Equal(t, "release", manifest.Releases[3].Triggers[0].Branch)
+		}
+	})
+
 	t.Run("UmarshallingManifestWithDeprecatedPipelinesVerbStillWorks", func(t *testing.T) {
 
 		input := `

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -253,6 +253,23 @@ func TestReadManifestFromFile(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsBuildTriggers", func(t *testing.T) {
+
+		// act
+		manifest, err := ReadManifestFromFile("test-manifest.yaml")
+
+		assert.Nil(t, err)
+
+		assert.Equal(t, 2, len(manifest.Triggers))
+		assert.Equal(t, "pipeline", manifest.Triggers[0].Type)
+		assert.Equal(t, "github.com/estafette/estafette-ci-manifest/build", manifest.Triggers[0].Reference)
+		assert.Equal(t, "release", manifest.Triggers[0].Branch)
+
+		assert.Equal(t, "pipeline", manifest.Triggers[1].Type)
+		assert.Equal(t, "github.com/estafette/estafette-ci-contracts/build", manifest.Triggers[1].Reference)
+		assert.Equal(t, "release", manifest.Triggers[1].Branch)
+	})
+
 	t.Run("ReturnsReleaseTargetWithTriggers", func(t *testing.T) {
 
 		// act
@@ -550,7 +567,7 @@ stages:
 		output, err := json.Marshal(manifest)
 
 		if assert.Nil(t, err) {
-			assert.Equal(t, "{\"Builder\":{\"Track\":\"stable\"},\"Labels\":{\"app\":\"estafette-ci-builder\",\"language\":\"golang\",\"team\":\"estafette-team\"},\"Version\":{\"SemVer\":{\"Major\":0,\"Minor\":0,\"Patch\":\"{{auto}}\",\"LabelTemplate\":\"{{branch}}\",\"ReleaseBranch\":\"master\"},\"Custom\":null},\"GlobalEnvVars\":null,\"Pipelines\":[{\"Name\":\"test-alpha-version\",\"ContainerImage\":\"extensions/gke:${ESTAFETTE_BUILD_VERSION}\",\"Shell\":\"/bin/sh\",\"WorkingDirectory\":\"/estafette-work\",\"Commands\":null,\"When\":\"status == 'succeeded'\",\"EnvVars\":null,\"AutoInjected\":false,\"Retries\":1,\"CustomProperties\":{\"app\":\"gke\",\"container\":{\"name\":\"gke\",\"repository\":\"extensions\",\"tag\":\"alpha\"},\"cpu\":{\"limit\":\"100m\",\"request\":\"100m\"},\"credentials\":\"gke-tooling\",\"dryrun\":true,\"memory\":{\"limit\":\"256Mi\",\"request\":\"256Mi\"},\"namespace\":\"estafette\",\"visibility\":\"private\"}}],\"Releases\":null}", string(output))
+			assert.Equal(t, "{\"Builder\":{\"Track\":\"stable\"},\"Labels\":{\"app\":\"estafette-ci-builder\",\"language\":\"golang\",\"team\":\"estafette-team\"},\"Version\":{\"SemVer\":{\"Major\":0,\"Minor\":0,\"Patch\":\"{{auto}}\",\"LabelTemplate\":\"{{branch}}\",\"ReleaseBranch\":\"master\"},\"Custom\":null},\"GlobalEnvVars\":null,\"Triggers\":null,\"Pipelines\":[{\"Name\":\"test-alpha-version\",\"ContainerImage\":\"extensions/gke:${ESTAFETTE_BUILD_VERSION}\",\"Shell\":\"/bin/sh\",\"WorkingDirectory\":\"/estafette-work\",\"Commands\":null,\"When\":\"status == 'succeeded'\",\"EnvVars\":null,\"AutoInjected\":false,\"Retries\":1,\"CustomProperties\":{\"app\":\"gke\",\"container\":{\"name\":\"gke\",\"repository\":\"extensions\",\"tag\":\"alpha\"},\"cpu\":{\"limit\":\"100m\",\"request\":\"100m\"},\"credentials\":\"gke-tooling\",\"dryrun\":true,\"memory\":{\"limit\":\"256Mi\",\"request\":\"256Mi\"},\"namespace\":\"estafette\",\"visibility\":\"private\"}}],\"Releases\":null}", string(output))
 		}
 	})
 }

--- a/release.go
+++ b/release.go
@@ -9,6 +9,7 @@ type EstafetteRelease struct {
 	Name            string                    `yaml:"-"`
 	CloneRepository bool                      `yaml:"clone,omitempty"`
 	Actions         []*EstafetteReleaseAction `yaml:"actions,omitempty"`
+	Triggers        []*EstafetteTrigger       `yaml:"triggers,omitempty"`
 	Stages          []*EstafetteStage         `yaml:"-"`
 }
 
@@ -19,6 +20,7 @@ func (release *EstafetteRelease) UnmarshalYAML(unmarshal func(interface{}) error
 		Name            string                    `yaml:"-"`
 		CloneRepository bool                      `yaml:"clone,omitempty"`
 		Actions         []*EstafetteReleaseAction `yaml:"actions,omitempty"`
+		Triggers        []*EstafetteTrigger       `yaml:"triggers,omitempty"`
 		Stages          yaml.MapSlice             `yaml:"stages"`
 	}
 
@@ -30,6 +32,7 @@ func (release *EstafetteRelease) UnmarshalYAML(unmarshal func(interface{}) error
 	// map auxiliary properties
 	release.CloneRepository = aux.CloneRepository
 	release.Actions = aux.Actions
+	release.Triggers = aux.Triggers
 
 	for _, mi := range aux.Stages {
 
@@ -58,9 +61,17 @@ func (release *EstafetteRelease) UnmarshalYAML(unmarshal func(interface{}) error
 func (release EstafetteRelease) MarshalYAML() (out interface{}, err error) {
 
 	var aux struct {
-		Name   string        `yaml:"-"`
-		Stages yaml.MapSlice `yaml:"stages"`
+		Name            string                    `yaml:"-"`
+		CloneRepository bool                      `yaml:"clone,omitempty"`
+		Actions         []*EstafetteReleaseAction `yaml:"actions,omitempty"`
+		Triggers        []*EstafetteTrigger       `yaml:"triggers,omitempty"`
+		Stages          yaml.MapSlice             `yaml:"stages"`
 	}
+
+	// map release properties
+	aux.CloneRepository = release.CloneRepository
+	aux.Actions = release.Actions
+	aux.Triggers = release.Triggers
 
 	for _, stage := range release.Stages {
 		aux.Stages = append(aux.Stages, yaml.MapItem{

--- a/releaseTrigger.go
+++ b/releaseTrigger.go
@@ -1,0 +1,8 @@
+package manifest
+
+// EstafetteTrigger defines an automated trigger to trigger a build or a release
+type EstafetteTrigger struct {
+	Type      string `yaml:"type" json:"type"`
+	Reference string `yaml:"ref" json:"ref"`
+	Branch    string `yaml:"branch,omitempty" json:"branch,omitempty"`
+}

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -21,10 +21,13 @@ env:
 triggers:
 - type: pipeline
   ref: github.com/estafette/estafette-ci-manifest/build
-  branch: release
+  filter: release
 - type: pipeline
   ref: github.com/estafette/estafette-ci-contracts/build
-  branch: release
+  filter: release
+- type: docker
+  ref: golang
+  filter: 1.8.0-alpine
 
 # automatically executed stages on a push to the repository
 stages:
@@ -113,7 +116,9 @@ releases:
     triggers:
     - type: pipeline
       ref: this/build
-      branch: any
+      filter: branch:release
+    - type: cron
+      ref: '*/5 * * * *'
 
     stages:
       deploy:
@@ -123,7 +128,6 @@ releases:
     triggers:
     - type: pipeline
       ref: this/releases/development
-      branch: release
 
     stages:
       deploy:

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -102,11 +102,21 @@ releases:
         - beta
 
   development:
+    triggers:
+    - type: pipeline
+      ref: this/build
+      branch: any
+
     stages:
       deploy:
         image: extensions/deploy-to-kubernetes-engine:dev
 
   staging:
+    triggers:
+    - type: pipeline
+      ref: this/releases/development
+      branch: release
+
     stages:
       deploy:
         image: extensions/gke:beta

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -19,15 +19,25 @@ env:
   VAR_B: World
 
 triggers:
-- type: pipeline
-  ref: github.com/estafette/estafette-ci-manifest/build
-  filter: release
-- type: pipeline
-  ref: github.com/estafette/estafette-ci-contracts/build
-  filter: release
-- type: docker
-  ref: golang
-  filter: 1.8.0-alpine
+- event: pipeline-build-finished
+  filter:
+    pipeline: github.com/estafette/estafette-ci-manifest
+    status: succeeded
+    branch: master|release
+  then:
+    branch: master
+- event: pipeline-build-started
+  filter:
+    pipeline: github.com/estafette/estafette-ci-contracts
+    branch: master|release
+  then:
+    branch: master
+- event: docker-image-pushed
+  filter:
+    image: golang
+    tag: 1\.8\..+
+  then:
+    branch: master
 
 # automatically executed stages on a push to the repository
 stages:
@@ -114,11 +124,17 @@ releases:
 
   development:
     triggers:
-    - type: pipeline
-      ref: this/build
-      filter: branch:release
-    - type: cron
-      ref: '*/5 * * * *'
+    - event: pipeline-build-finished
+      filter:
+        status: succeeded
+        branch: .+
+      then:
+        branch: .+
+    - event: cron
+      filter:
+        cron: '*/5 * * * *'
+      then:
+        branch: master
 
     stages:
       deploy:
@@ -126,8 +142,13 @@ releases:
 
   staging:
     triggers:
-    - type: pipeline
-      ref: this/releases/development
+    - event: pipeline-release-finished
+      filter:
+        target: development
+        status: succeeded
+        branch: master
+      then:
+        branch: master
 
     stages:
       deploy:
@@ -151,6 +172,16 @@ releases:
     - name: deploy-canary
     - name: rollback-canary
     - name: deploy-stable
+
+    triggers:
+    - event: pipeline-release-finished
+      filter:
+        target: staging
+        status: succeeded
+        branch: master
+      then:
+        branch: master
+        action: deploy-canary
 
     clone: true
     stages:

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -24,19 +24,19 @@ triggers:
     pipeline: github.com/estafette/estafette-ci-manifest
     status: succeeded
     branch: master|release
-  then:
+  run:
     branch: master
 - event: pipeline-build-started
   filter:
     pipeline: github.com/estafette/estafette-ci-contracts
     branch: master|release
-  then:
+  run:
     branch: master
 - event: docker-image-pushed
   filter:
     image: golang
     tag: 1\.8\..+
-  then:
+  run:
     branch: master
 
 # automatically executed stages on a push to the repository
@@ -128,12 +128,12 @@ releases:
       filter:
         status: succeeded
         branch: .+
-      then:
+      run:
         branch: .+
     - event: cron
       filter:
         cron: '*/5 * * * *'
-      then:
+      run:
         branch: master
 
     stages:
@@ -148,7 +148,7 @@ releases:
         target: development
         status: succeeded
         branch: master
-      then:
+      run:
         branch: master
 
     stages:
@@ -180,7 +180,7 @@ releases:
         target: staging
         status: succeeded
         branch: master
-      then:
+      run:
         branch: master
         action: deploy-canary
 

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -18,6 +18,14 @@ env:
   VAR_A: Greetings
   VAR_B: World
 
+triggers:
+- type: pipeline
+  ref: github.com/estafette/estafette-ci-manifest/build
+  branch: release
+- type: pipeline
+  ref: github.com/estafette/estafette-ci-contracts/build
+  branch: release
+
 # automatically executed stages on a push to the repository
 stages:
   build:

--- a/test-manifest.yaml
+++ b/test-manifest.yaml
@@ -144,6 +144,7 @@ releases:
     triggers:
     - event: pipeline-release-finished
       filter:
+        pipeline: this
         target: development
         status: succeeded
         branch: master

--- a/trigger.go
+++ b/trigger.go
@@ -4,7 +4,7 @@ package manifest
 type EstafetteTrigger struct {
 	Event  string                  `yaml:"event,omitempty" json:"event,omitempty"`
 	Filter *EstafetteTriggerFilter `yaml:"filter,omitempty" json:"filter,omitempty"`
-	Then   *EstafetteTriggerThen   `yaml:"then,omitempty" json:"then,omitempty"`
+	Run    *EstafetteTriggerRun    `yaml:"run,omitempty" json:"run,omitempty"`
 }
 
 // EstafetteTriggerFilter filters the triggered event
@@ -24,8 +24,8 @@ type EstafetteTriggerFilter struct {
 	Tag   string `yaml:"tag,omitempty" json:"tag,omitempty"`
 }
 
-// EstafetteTriggerThen determines what's triggered when filtered events arive
-type EstafetteTriggerThen struct {
+// EstafetteTriggerRun determines what action to take on a trigger
+type EstafetteTriggerRun struct {
 	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
 	Action string `yaml:"action,omitempty" json:"action,omitempty"`
 }
@@ -36,7 +36,7 @@ func (t *EstafetteTrigger) UnmarshalYAML(unmarshal func(interface{}) error) (err
 	var aux struct {
 		Event  string                  `yaml:"event,omitempty" json:"event,omitempty"`
 		Filter *EstafetteTriggerFilter `yaml:"filter,omitempty" json:"filter,omitempty"`
-		Then   *EstafetteTriggerThen   `yaml:"then,omitempty" json:"then,omitempty"`
+		Run    *EstafetteTriggerRun    `yaml:"run,omitempty" json:"run,omitempty"`
 	}
 
 	// unmarshal to auxiliary type
@@ -47,7 +47,7 @@ func (t *EstafetteTrigger) UnmarshalYAML(unmarshal func(interface{}) error) (err
 	// map auxiliary properties
 	t.Event = aux.Event
 	t.Filter = aux.Filter
-	t.Then = aux.Then
+	t.Run = aux.Run
 
 	t.SetDefaults()
 
@@ -66,9 +66,6 @@ func (t *EstafetteTrigger) SetDefaults() {
 		if t.Filter == nil {
 			t.Filter = &EstafetteTriggerFilter{}
 		}
-		if t.Then == nil {
-			t.Then = &EstafetteTriggerThen{}
-		}
 	}
 
 	// set filter branch default
@@ -83,21 +80,6 @@ func (t *EstafetteTrigger) SetDefaults() {
 		"pipeline-release-finished":
 		if t.Filter.Branch == "" {
 			t.Filter.Branch = ".+"
-		}
-	}
-
-	// set then branch default
-	switch t.Event {
-	case "pipeline-build-started",
-		"pipeline-build-finished":
-		if t.Then.Branch == "" {
-			t.Then.Branch = "master"
-		}
-
-	case "pipeline-release-started",
-		"pipeline-release-finished":
-		if t.Then.Branch == "" {
-			t.Then.Branch = ".+"
 		}
 	}
 
@@ -116,6 +98,32 @@ func (t *EstafetteTrigger) SetDefaults() {
 		"pipeline-release-finished":
 		if t.Filter.Status == "" {
 			t.Filter.Status = "succeeded"
+		}
+	}
+
+	// set run default
+	switch t.Event {
+	case "pipeline-build-started",
+		"pipeline-build-finished",
+		"pipeline-release-started",
+		"pipeline-release-finished":
+		if t.Run == nil {
+			t.Run = &EstafetteTriggerRun{}
+		}
+	}
+
+	// set run branch default
+	switch t.Event {
+	case "pipeline-build-started",
+		"pipeline-build-finished":
+		if t.Run.Branch == "" {
+			t.Run.Branch = "master"
+		}
+
+	case "pipeline-release-started",
+		"pipeline-release-finished":
+		if t.Run.Branch == "" {
+			t.Run.Branch = ".+"
 		}
 	}
 }

--- a/trigger.go
+++ b/trigger.go
@@ -127,3 +127,97 @@ func (t *EstafetteTrigger) SetDefaults() {
 		}
 	}
 }
+
+// Equals returns true if the event, all filters and run options match
+func (t *EstafetteTrigger) Equals(trigger *EstafetteTrigger) bool {
+
+	if t == nil && trigger == nil {
+		return true
+	}
+
+	if t == nil || trigger == nil {
+		return false
+	}
+
+	if t.Event != trigger.Event {
+		return false
+	}
+
+	if !t.Filter.Equals(trigger.Filter) {
+		return false
+	}
+
+	if !t.Run.Equals(trigger.Run) {
+		return false
+	}
+
+	return true
+}
+
+// Equals returns true if all filters options match
+func (f *EstafetteTriggerFilter) Equals(filter *EstafetteTriggerFilter) bool {
+
+	if f == nil && filter == nil {
+		return true
+	}
+
+	if f == nil || filter == nil {
+		return false
+	}
+
+	if f.Pipeline != filter.Pipeline {
+		return false
+	}
+
+	if f.Target != filter.Target {
+		return false
+	}
+
+	if f.Action != filter.Action {
+		return false
+	}
+
+	if f.Status != filter.Status {
+		return false
+	}
+
+	if f.Branch != filter.Branch {
+		return false
+	}
+
+	if f.Cron != filter.Cron {
+		return false
+	}
+
+	if f.Image != filter.Image {
+		return false
+	}
+
+	if f.Tag != filter.Tag {
+		return false
+	}
+
+	return true
+}
+
+// Equals returns true if all run options match
+func (r *EstafetteTriggerRun) Equals(run *EstafetteTriggerRun) bool {
+
+	if r == nil && run == nil {
+		return true
+	}
+
+	if r == nil || run == nil {
+		return false
+	}
+
+	if r.Branch != run.Branch {
+		return false
+	}
+
+	if r.Action != run.Action {
+		return false
+	}
+
+	return true
+}

--- a/trigger.go
+++ b/trigger.go
@@ -2,7 +2,30 @@ package manifest
 
 // EstafetteTrigger defines an automated trigger to trigger a build or a release
 type EstafetteTrigger struct {
-	Type      string `yaml:"type" json:"type"`
-	Reference string `yaml:"ref" json:"ref"`
-	Filter    string `yaml:"filter,omitempty" json:"filter,omitempty"`
+	Event  string                  `yaml:"event,omitempty" json:"event,omitempty"`
+	Filter *EstafetteTriggerFilter `yaml:"filter,omitempty" json:"filter,omitempty"`
+	Then   *EstafetteTriggerThen   `yaml:"then,omitempty" json:"then,omitempty"`
+}
+
+// EstafetteTriggerFilter filters the triggered event
+type EstafetteTriggerFilter struct {
+	// pipeline related filtering
+	Pipeline string `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
+	Target   string `yaml:"target,omitempty" json:"target,omitempty"`
+	Action   string `yaml:"action,omitempty" json:"action,omitempty"`
+	Status   string `yaml:"status,omitempty" json:"status,omitempty"`
+	Branch   string `yaml:"branch,omitempty" json:"branch,omitempty"`
+
+	// cron related filtering
+	Cron string `yaml:"cron,omitempty" json:"cron,omitempty"`
+
+	// docker related filtering
+	Image string `yaml:"image,omitempty" json:"image,omitempty"`
+	Tag   string `yaml:"tag,omitempty" json:"tag,omitempty"`
+}
+
+// EstafetteTriggerThen determines what's triggered when filtered events arive
+type EstafetteTriggerThen struct {
+	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	Action string `yaml:"action,omitempty" json:"action,omitempty"`
 }

--- a/trigger.go
+++ b/trigger.go
@@ -29,3 +29,93 @@ type EstafetteTriggerThen struct {
 	Branch string `yaml:"branch,omitempty" json:"branch,omitempty"`
 	Action string `yaml:"action,omitempty" json:"action,omitempty"`
 }
+
+// UnmarshalYAML customizes unmarshalling an EstafetteTrigger
+func (t *EstafetteTrigger) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
+
+	var aux struct {
+		Event  string                  `yaml:"event,omitempty" json:"event,omitempty"`
+		Filter *EstafetteTriggerFilter `yaml:"filter,omitempty" json:"filter,omitempty"`
+		Then   *EstafetteTriggerThen   `yaml:"then,omitempty" json:"then,omitempty"`
+	}
+
+	// unmarshal to auxiliary type
+	if err := unmarshal(&aux); err != nil {
+		return err
+	}
+
+	// map auxiliary properties
+	t.Event = aux.Event
+	t.Filter = aux.Filter
+	t.Then = aux.Then
+
+	t.SetDefaults()
+
+	return nil
+}
+
+// SetDefaults sets event-specific defaults
+func (t *EstafetteTrigger) SetDefaults() {
+
+	// set filter default
+	switch t.Event {
+	case "pipeline-build-started",
+		"pipeline-build-finished",
+		"pipeline-release-started",
+		"pipeline-release-finished":
+		if t.Filter == nil {
+			t.Filter = &EstafetteTriggerFilter{}
+		}
+		if t.Then == nil {
+			t.Then = &EstafetteTriggerThen{}
+		}
+	}
+
+	// set filter branch default
+	switch t.Event {
+	case "pipeline-build-started",
+		"pipeline-build-finished":
+		if t.Filter.Branch == "" {
+			t.Filter.Branch = "master"
+		}
+
+	case "pipeline-release-started",
+		"pipeline-release-finished":
+		if t.Filter.Branch == "" {
+			t.Filter.Branch = ".+"
+		}
+	}
+
+	// set then branch default
+	switch t.Event {
+	case "pipeline-build-started",
+		"pipeline-build-finished":
+		if t.Then.Branch == "" {
+			t.Then.Branch = "master"
+		}
+
+	case "pipeline-release-started",
+		"pipeline-release-finished":
+		if t.Then.Branch == "" {
+			t.Then.Branch = ".+"
+		}
+	}
+
+	// set filter pipeline default
+	switch t.Event {
+	case "pipeline-release-started",
+		"pipeline-release-finished":
+		if t.Filter.Pipeline == "" {
+			t.Filter.Pipeline = "this"
+		}
+	}
+
+	// set filter pipeline default
+	switch t.Event {
+	case "pipeline-build-finished",
+		"pipeline-release-finished":
+		if t.Filter.Status == "" {
+			t.Filter.Status = "succeeded"
+		}
+	}
+}

--- a/trigger.go
+++ b/trigger.go
@@ -4,5 +4,5 @@ package manifest
 type EstafetteTrigger struct {
 	Type      string `yaml:"type" json:"type"`
 	Reference string `yaml:"ref" json:"ref"`
-	Branch    string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	Filter    string `yaml:"filter,omitempty" json:"filter,omitempty"`
 }

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -1,0 +1,154 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetDefaults(t *testing.T) {
+
+	t.Run("DefaultsFilterBranchToMasterForEventPipelineBuildStarted", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-build-started",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "master", trigger.Filter.Branch)
+	})
+
+	t.Run("DefaultsFilterBranchToMasterForEventPipelineBuildFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-build-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "master", trigger.Filter.Branch)
+	})
+
+	t.Run("DefaultsFilterStatusToSucceededForEventPipelineBuildFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-build-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "succeeded", trigger.Filter.Status)
+	})
+
+	t.Run("DefaultsFilterBranchToAnyForEventPipelineReleaseStarted", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-started",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, ".+", trigger.Filter.Branch)
+	})
+
+	t.Run("DefaultsFilterBranchToAnyForEventPipelineReleaseFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, ".+", trigger.Filter.Branch)
+	})
+
+	t.Run("DefaultsFilterStatusToSucceededForEventPipelineReleaseFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "succeeded", trigger.Filter.Status)
+	})
+
+	t.Run("DefaultsFilterPipelineToThisPipelineToAnyForEventPipelineReleaseStarted", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-started",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "this", trigger.Filter.Pipeline)
+	})
+
+	t.Run("DefaultsFilterPipelineToThisPipelineToAnyForEventPipelineReleaseFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "this", trigger.Filter.Pipeline)
+	})
+
+	t.Run("DefaultsThenBranchToMasterForEventPipelineBuildStarted", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-build-started",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "master", trigger.Then.Branch)
+	})
+
+	t.Run("DefaultsThenBranchToMasterForEventPipelineBuildFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-build-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, "master", trigger.Then.Branch)
+	})
+
+	t.Run("DefaultsThenBranchToAnyForEventPipelineReleaseStarted", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-started",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, ".+", trigger.Then.Branch)
+	})
+
+	t.Run("DefaultsThenBranchToAnyForEventPipelineReleaseFinished", func(t *testing.T) {
+
+		trigger := EstafetteTrigger{
+			Event: "pipeline-release-finished",
+		}
+
+		// act
+		trigger.SetDefaults()
+
+		assert.Equal(t, ".+", trigger.Then.Branch)
+	})
+}

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -113,7 +113,7 @@ func TestSetDefaults(t *testing.T) {
 		// act
 		trigger.SetDefaults()
 
-		assert.Equal(t, "master", trigger.Then.Branch)
+		assert.Equal(t, "master", trigger.Run.Branch)
 	})
 
 	t.Run("DefaultsThenBranchToMasterForEventPipelineBuildFinished", func(t *testing.T) {
@@ -125,7 +125,7 @@ func TestSetDefaults(t *testing.T) {
 		// act
 		trigger.SetDefaults()
 
-		assert.Equal(t, "master", trigger.Then.Branch)
+		assert.Equal(t, "master", trigger.Run.Branch)
 	})
 
 	t.Run("DefaultsThenBranchToAnyForEventPipelineReleaseStarted", func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestSetDefaults(t *testing.T) {
 		// act
 		trigger.SetDefaults()
 
-		assert.Equal(t, ".+", trigger.Then.Branch)
+		assert.Equal(t, ".+", trigger.Run.Branch)
 	})
 
 	t.Run("DefaultsThenBranchToAnyForEventPipelineReleaseFinished", func(t *testing.T) {
@@ -149,6 +149,6 @@ func TestSetDefaults(t *testing.T) {
 		// act
 		trigger.SetDefaults()
 
-		assert.Equal(t, ".+", trigger.Then.Branch)
+		assert.Equal(t, ".+", trigger.Run.Branch)
 	})
 }

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -152,3 +152,404 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, ".+", trigger.Run.Branch)
 	})
 }
+
+func TestRunEquals(t *testing.T) {
+
+	t.Run("ReturnsTrueIfBothRunObjectsAreNil", func(t *testing.T) {
+
+		var run1 *EstafetteTriggerRun
+		var run2 *EstafetteTriggerRun
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.True(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfOneIsNilAndTheOtherIsNot", func(t *testing.T) {
+
+		var run1 *EstafetteTriggerRun
+		run2 := &EstafetteTriggerRun{}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfOneIsNilAndTheOtherIsNotReversed", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerRun{}
+		var run2 *EstafetteTriggerRun
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfBranchIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerRun{
+			Branch: "master",
+		}
+		run2 := &EstafetteTriggerRun{
+			Branch: "development",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfActionIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerRun{
+			Action: "deploy-canary",
+		}
+		run2 := &EstafetteTriggerRun{
+			Action: "deploy-stable",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsTrueIfAllOptionsAreEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerRun{
+			Branch: "master",
+			Action: "deploy-canary",
+		}
+		run2 := &EstafetteTriggerRun{
+			Branch: "master",
+			Action: "deploy-canary",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.True(t, equal)
+	})
+}
+
+func TestFilterEquals(t *testing.T) {
+
+	t.Run("ReturnsTrueIfBothRunObjectsAreNil", func(t *testing.T) {
+
+		var run1 *EstafetteTriggerFilter
+		var run2 *EstafetteTriggerFilter
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.True(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfOneIsNilAndTheOtherIsNot", func(t *testing.T) {
+
+		var run1 *EstafetteTriggerFilter
+		run2 := &EstafetteTriggerFilter{}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfOneIsNilAndTheOtherIsNotReversed", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{}
+		var run2 *EstafetteTriggerFilter
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfPipelineIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Pipeline: "this",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Pipeline: "github.com/estafette/estafette-extensions-gke",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfBranchIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Branch: "master",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Branch: "development",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfActionIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Action: "deploy-canary",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Action: "deploy-stable",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfTargetIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Target: "beta",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Target: "stable",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfStatusIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Status: "succeeded",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Status: "failed",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfCronIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Cron: "*/5 * * * *",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Cron: "*/6 * * * *",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfImageIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Image: "golang",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Image: "node",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfTagIsNotEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Tag: "1.11.2-alpine3.8",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Tag: "1.11-alpine3.8",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsTrueIfAllOptionsAreEqual", func(t *testing.T) {
+
+		run1 := &EstafetteTriggerFilter{
+			Pipeline: "github.com/estafette/estafette-extensions-gke",
+			Branch:   "master",
+			Action:   "deploy-canary",
+			Target:   "stable",
+			Status:   "succeeded",
+			Cron:     "*/5 * * * *",
+			Image:    "golang",
+			Tag:      "1.11.2-alpine3.8",
+		}
+		run2 := &EstafetteTriggerFilter{
+			Pipeline: "github.com/estafette/estafette-extensions-gke",
+			Branch:   "master",
+			Action:   "deploy-canary",
+			Target:   "stable",
+			Status:   "succeeded",
+			Cron:     "*/5 * * * *",
+			Image:    "golang",
+			Tag:      "1.11.2-alpine3.8",
+		}
+
+		// act
+		equal := run1.Equals(run2)
+
+		assert.True(t, equal)
+	})
+}
+
+func TestTriggerEquals(t *testing.T) {
+
+	t.Run("ReturnsTrueIfBothRunObjectsAreNil", func(t *testing.T) {
+
+		var trigger1 *EstafetteTrigger
+		var trigger2 *EstafetteTrigger
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.True(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfOneIsNilAndTheOtherIsNot", func(t *testing.T) {
+
+		var trigger1 *EstafetteTrigger
+		trigger2 := &EstafetteTrigger{}
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfOneIsNilAndTheOtherIsNotReversed", func(t *testing.T) {
+
+		trigger1 := &EstafetteTrigger{}
+		var trigger2 *EstafetteTrigger
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfEventIsNotEqual", func(t *testing.T) {
+
+		trigger1 := &EstafetteTrigger{
+			Event: "pipeline-build-finished",
+		}
+		trigger2 := &EstafetteTrigger{
+			Event: "pipeline-build-started",
+		}
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfFilterIsNotEqual", func(t *testing.T) {
+
+		trigger1 := &EstafetteTrigger{
+			Filter: &EstafetteTriggerFilter{
+				Pipeline: "this",
+			},
+		}
+		trigger2 := &EstafetteTrigger{
+			Filter: &EstafetteTriggerFilter{
+				Pipeline: "github.com/estafette/estafette-extension-gke",
+			},
+		}
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsFalseIfRunIsNotEqual", func(t *testing.T) {
+
+		trigger1 := &EstafetteTrigger{
+			Run: &EstafetteTriggerRun{
+				Branch: "master",
+			},
+		}
+		trigger2 := &EstafetteTrigger{
+			Run: &EstafetteTriggerRun{
+				Branch: "development",
+			},
+		}
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.False(t, equal)
+	})
+
+	t.Run("ReturnsTrueIfAllOptionsAreEqual", func(t *testing.T) {
+
+		trigger1 := &EstafetteTrigger{
+			Event: "pipeline-build-finished",
+			Filter: &EstafetteTriggerFilter{
+				Pipeline: "github.com/estafette/estafette-extensions-gke",
+				Branch:   "master",
+				Action:   "deploy-canary",
+				Target:   "stable",
+				Status:   "succeeded",
+				Cron:     "*/5 * * * *",
+				Image:    "golang",
+				Tag:      "1.11.2-alpine3.8",
+			},
+			Run: &EstafetteTriggerRun{
+				Branch: "master",
+				Action: "deploy-canary",
+			},
+		}
+		trigger2 := &EstafetteTrigger{
+			Event: "pipeline-build-finished",
+			Filter: &EstafetteTriggerFilter{
+				Pipeline: "github.com/estafette/estafette-extensions-gke",
+				Branch:   "master",
+				Action:   "deploy-canary",
+				Target:   "stable",
+				Status:   "succeeded",
+				Cron:     "*/5 * * * *",
+				Image:    "golang",
+				Tag:      "1.11.2-alpine3.8",
+			},
+			Run: &EstafetteTriggerRun{
+				Branch: "master",
+				Action: "deploy-canary",
+			},
+		}
+
+		// act
+		equal := trigger1.Equals(trigger2)
+
+		assert.True(t, equal)
+	})
+
+}


### PR DESCRIPTION
I'm investigating what triggers in the estafette manifest could look like.

For type I think we'll have options like `pipeline`, `docker`, `cron` or whatever webhook we can integrate with.

We then need a way to describe which pipeline or docker container we're interested in and then filter anything we don't want to trigger on. Perhaps `branch` is a bit too pipeline-specific, `filter` perhaps?

Also it needs to be considered whether these triggers and filters are used to limit what can make it's way from release target to release target (when we only want to allow successful builds to development to make it to staging) or that we need additional filter for that.